### PR TITLE
Fix to Background Setting style

### DIFF
--- a/src/ui-components/background-setting.scss
+++ b/src/ui-components/background-setting.scss
@@ -29,4 +29,5 @@
   padding-top:45px;
   font-size: 32px;
   border: 1px solid #CCC;
+  line-height: 0px;
 }


### PR DESCRIPTION
- Ensuring no `line-height` gets applied so the icon gets position correctly by the `padding-top` value