### PR TITLE
Styles for Product Details

### DIFF
--- a/src/sections/store.scss
+++ b/src/sections/store.scss
@@ -425,3 +425,56 @@
 
 
 
+.product-details
+{
+  h3
+  {
+    margin: 22px 0 11px 0;
+  }
+  .product-name
+  {
+    margin-top: 33px;
+  }
+  .purchase-form__button button
+  {
+    &.btn-primary
+    {
+      width: 100%;
+      margin-bottom: 5px;
+    }
+    &.btn-default
+    {
+      width: 100%;
+      margin-bottom: 5px;
+    }
+    &.btn-link
+    {
+      font-size: 14px;
+
+      width: 100%;
+      margin-bottom: 5px;
+    }
+    i
+    {
+      margin-right: 5px;
+    }
+  }
+}
+
+@media screen and(max-width: 660px)
+{
+  .product-details .mobile-filters
+  {
+    position: relative;
+    top: 20px;
+    button i
+    {
+      margin-right: 5px;
+    }
+  }
+}
+.owl-item a img
+{
+  width: 94% !important;
+  height: 332px !important;
+}


### PR DESCRIPTION
@ghislaineguerin @mmeiers 

Pull Request for Product Details:

Project Doc - https://docs.google.com/document/d/1syfkf8vBrKWaLjxWVtsXOwtHQdZtLMB4kYHTLMmYEYU/

UX Repo -  https://github.com/Rise-Vision/ux-prototypes/tree/store-mockup

S3 Links - 
(store) https://s3.amazonaws.com/ux-design/store-mockups/product-details.html 
(in-app) https://s3.amazonaws.com/ux-design/store-mockups/fromEditor.html 

Notes:
Added some styles for a new 'Product Details' page.  Fairly simple as part of Common Style, but I'm suggesting that there be a separate CSS call as part of Store's build file.
There is a lot going on in the front-end with this one (slider, popup gallery, thumbnail generation) that I'm thinking would not be useful elsewhere for RV?  Let me know your thoughts and if you agree.
(Full breakdown here:  https://github.com/Rise-Vision/ux-prototypes/blob/store-mockup/product-details.css )

@brianloosbrock FYI

