### PR TITLE
added global padding and sizing for storage selector icon

### DIFF
--- a/src/core/global.scss
+++ b/src/core/global.scss
@@ -546,11 +546,13 @@ a.btn-primary:hover {
 .add-right { margin-right: 10px !important; }
 
 .remove-bottom { margin-bottom: 0 !important; }
+.small-bottom {padding-bottom: 3px !important; }
 .half-bottom { margin-bottom: 10px !important; }
 .add-bottom { margin-bottom: 20px !important; }
 .add-bottom-double { margin-bottom: 40px !important; }
 
 .remove-top { margin-top: 0 !important; }
+.small-top {padding-top: 3px !important; }
 .half-top { margin-top: 10px !important; }
 .add-top { margin-top: 20px !important; }
 .add-top-double { margin-top: 40px !important; }

--- a/src/sections/widgets.scss
+++ b/src/sections/widgets.scss
@@ -57,6 +57,10 @@
   width:100%; 
 }
 
+.storage-selector-icon {
+  height:20px;
+}
+
 .widget {
   height: 100%;
 


### PR DESCRIPTION
@adriandd @ghislaineguerin Here is a new pr for video widget settings.
Ill make sure to leave it open until everything is finalized this time.

I needed a small amount of padding to vertically center my text and icon within the input group field.
I also created a class to size the storage selector icon.
http://www.screencast.com/t/1wKBbUBIc