### PR TITLE
Upgrade gulp-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gulp-watch": "^0.5.4",
     "gulp-jsoncombine": "1.0.0",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "2.1.0"
+    "gulp-sass": "3.1.0"
   },
   "devDependencies": {
     "bower": "^1.3.3",


### PR DESCRIPTION
This particular version doesn't work with node >6.0
Upgraded dependency to fix as we're moving to higher node versions overall